### PR TITLE
Problem: People need to be prodded about abandoning problems (#10)

### DIFF
--- a/src/events/activity.js
+++ b/src/events/activity.js
@@ -151,6 +151,10 @@ async function scrapeInactiveIssues(references, issues) {
       this.issues.editComment({
         owner: repoOwner, repo: repoName, comment_id: id, body: warning
       });
+
+      this.issues.addLabels({
+        owner: repoOwner, repo: repoName, number: number, labels: ['unclaimed']
+      });
     } else if (time + ims <= Date.now()) {
       this.issues.createComment({
         owner: repoOwner, repo: repoName, number: number, body: comment


### PR DESCRIPTION
Solution: Change the 10 day warning to appear after 2 days, and change the 14 day kick to 3 days. In addition, so that people really know the issue is open again, label the issue as "unclaimed".